### PR TITLE
chore: update to latest Alloy

### DIFF
--- a/Socket.lean
+++ b/Socket.lean
@@ -250,15 +250,15 @@ instance : Coe SockAddrUnix SockAddr where
 
 alloy c extern "lean_sockaddr_in_family"
 def SockAddr4.family (addr : @& SockAddr4) : AddressFamily :=
-  return of_lean<SockAddr4>(lean_ctor_get(addr, 0))->sin_family;
+  return of_lean<SockAddr4>(addr)->sin_family;
 
 alloy c extern "lean_sockaddr_in6_family"
 def SockAddr6.family (addr : @& SockAddr6) : AddressFamily :=
-  return of_lean<SockAddr6>(lean_ctor_get(addr, 0))->sin6_family;
+  return of_lean<SockAddr6>(addr)->sin6_family;
 
 alloy c extern "lean_sockaddr_un_family"
 def SockAddrUnix.family (addr : @& SockAddrUnix) : AddressFamily :=
-  return of_lean<SockAddrUnix>(lean_ctor_get(addr, 0))->sun_family;
+  return of_lean<SockAddrUnix>(addr)->sun_family;
 
 /--
 Get the `AddressFamily` of a `SockAddr`.

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"git":
    {"url": "https://github.com/tydeu/lean4-alloy/",
     "subDir?": null,
-    "rev": "691d6097a753e0a7fd9f23b978c079de57efc9bf",
+    "rev": "10e0a135b578eed084ebf3a082d801abcc0e646c",
     "opts": {},
     "name": "alloy",
     "inputRev?": "master",


### PR DESCRIPTION
I have upstreamed versions of `alloy c enum` and `alloy c alloc` to Alloy (the later of which I made into the more general `alloy c extern_type`). This commands autogenerate translator functions (with automatic names) that can be dynamically accessed through the `to_lean` and `of_lean` custom C syntax. I have updated your code accordingly to make use of these features.

I would appreciate any feedback you may have on this design! One minor bikeshedding question I have for you is: Do you think the name `mk_lean` would be better than current `to_lean` for its function (wrapping a C value in a Lean value)?