### PR TITLE
update alloy and syntax

### DIFF
--- a/Socket.lean
+++ b/Socket.lean
@@ -40,7 +40,7 @@ A platform specific socket type. The usual main interaction points with this typ
 2. `Socket.connect` to use a `Socket` as a client to connect somewhere
 3. `Socket.bind`, `Socket.listen` and finally `Socket.accept` to host a server with a `Socket`
 -/
-alloy c extern_type Socket => int := {
+alloy c opaque_extern_type Socket => int := {
   foreach := `noop_foreach
   finalize := `socket_finalize
 }
@@ -118,17 +118,17 @@ static void sockaddr_un_finalize(void* ptr) {
 }
 end
 
-alloy c extern_type SockAddr4 => struct sockaddr_in := {
+alloy c opaque_extern_type SockAddr4 => struct sockaddr_in := {
   finalize := `sockaddr_in_finalize
   foreach := `noop_foreach
 }
 
-alloy c extern_type SockAddr6 => struct sockaddr_in6 := {
+alloy c opaque_extern_type SockAddr6 => struct sockaddr_in6 := {
   finalize := `sockaddr_in6_finalize
   foreach := `noop_foreach
 }
 
-alloy c extern_type SockAddrUnix => struct sockaddr_un := {
+alloy c opaque_extern_type SockAddrUnix => struct sockaddr_un := {
   finalize := `sockaddr_un_finalize
   foreach := `noop_foreach
 }

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,10 +1,10 @@
-{"version": 5,
+{"version": 6,
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
    {"url": "https://github.com/tydeu/lean4-alloy/",
     "subDir?": null,
-    "rev": "10e0a135b578eed084ebf3a082d801abcc0e646c",
+    "rev": "9abdb9b2e3ac6a7b7cd9a04656d5385f4e265fa9",
     "opts": {},
     "name": "alloy",
     "inputRev?": "master",
@@ -12,8 +12,9 @@
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "b5f7bd40d2162fe148e585543f284a5d8cc0ef26",
+    "rev": "e403f680f0beb8610c29e6f799132e8be880554e",
     "opts": {},
     "name": "std",
     "inputRev?": "main",
-    "inherited": false}}]}
+    "inherited": false}}],
+ "name": "socket"}

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-08-19
+leanprover/lean4:4.2.0


### PR DESCRIPTION
Bit of a syntax swap over at alloy, see https://github.com/tydeu/lean4-alloy/commit/9abdb9b2e3ac6a7b7cd9a04656d5385f4e265fa9

It wouldn't matter much except that the currently pinned version of alloy is not quite working well with 4.12 (couple of very minor changes like using arrays instead of lists in `importModules` and such which were already fixed in recent commits over at alloy).