### PR TITLE
feature: make unix sockets work

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -1,8 +1,20 @@
 import Socket
 
-def client (arg : String) : IO Unit := do
+def mkSocketV4: IO (Socket × Socket.SockAddr) := do
   let sock ← Socket.mk .inet .stream
-  let sa : Socket.SockAddr4 := .v4 (.mk 127 0 0 1) 8888
+  pure (sock, Socket.SockAddr4.v4 (.mk 127 0 0 1) 8888)
+
+def mkSocketV6: IO (Socket × Socket.SockAddr) := do
+  let sock ← Socket.mk .inet6 .stream
+  pure (sock, Socket.SockAddr6.v6 (.mk 0 0 0 0 0 0 0 1) 8888)
+
+def mkSocketUnix: IO (Socket × Socket.SockAddr) := do
+  let sock ← Socket.mk .unix .stream
+  pure (sock, Socket.SockAddrUnix.unix "./unix.addr")
+
+
+def client (arg : String) (input : Socket × Socket.SockAddr): IO Unit := do
+  let (sock, sa) := input
   sock.connect sa
   let bytes := arg.toUTF8
   let _ ← sock.send bytes
@@ -19,9 +31,8 @@ def handle (client : Socket) : IO Unit := do
   let _ ← client.send recv
   IO.println "Done handling"
 
-def server : IO Unit := do
-  let sock ← Socket.mk .inet .stream
-  let sa : Socket.SockAddr4 := .v4 (.mk 127 0 0 1) 8888
+def server (input : Socket × Socket.SockAddr) : IO Unit := do
+  let (sock, sa) := input
   sock.bind sa
   sock.listen 1
   while true do
@@ -31,10 +42,26 @@ def server : IO Unit := do
 
 def main (args : List String) : IO Unit := do
   let mode := args.get! 0
-  if mode == "client" then
-    client <| args.get! 1
+  if mode == "client" then do
+    let type := args.get! 1
+    if type == "v4" then
+        mkSocketV4 >>= client (args.get! 2)
+    else if type == "v6" then
+        mkSocketV6 >>= client (args.get! 2)
+    else if type == "unix" then
+        mkSocketUnix >>= client (args.get! 2)
+    else
+        mkSocketV4 >>= client type
+
   else if mode == "server" then
-    server
+    let type := args.get! 1
+    if type == "unix" then
+      mkSocketUnix >>= server
+    else if type == "v6" then
+      mkSocketV6 >>= server
+    else
+      mkSocketV4 >>= server
+
   else
     IO.println "Unknown mode"
     return ()

--- a/Socket.lean
+++ b/Socket.lean
@@ -338,6 +338,9 @@ def connect (socket : @& Socket) (addr : @& SockAddr) : IO Unit := {
     case 1:
       err = connect(fd, sa, sizeof(struct sockaddr_in6));
       break;
+    case 2:
+      err = connect(fd, sa, sizeof(struct sockaddr_un));
+      break;
     default:
       return lean_panic_fn(lean_box(0), lean_mk_string("illegal C value"));
   }
@@ -396,6 +399,16 @@ def sendto (socket : @& Socket) (buf : @& ByteArray) (addr : @& SockAddr) : IO U
         sizeof(struct sockaddr_in6)
       );
       break;
+    case 2:
+      bytes = sendto(
+        fd,
+        lean_sarray_cptr(buf),
+        lean_sarray_size(buf),
+        0,
+        sa,
+        sizeof(struct sockaddr_un)
+      );
+      break;
     default:
       return lean_panic_fn(lean_box(0), lean_mk_string("illegal C value"));
   }
@@ -444,6 +457,9 @@ def bind (socket : @& Socket) (addr : @& SockAddr) : IO Unit := {
       break;
     case 1:
       err = bind(fd, sa, sizeof(struct sockaddr_in6));
+      break;
+    case 2:
+      err = bind(fd, sa, sizeof(struct sockaddr_un));
       break;
     default:
       return lean_panic_fn(lean_box(0), lean_mk_string("illegal C value"));


### PR DESCRIPTION
Tested it locally and it seems to work (both reading and writing):

```lean
  let unix <- Socket.mk Socket.AddressFamily.unix Socket.Typ.stream
  unix.connect $ Socket.SockAddrUnix.unix ctl
  _ <- unix.send "dispatch dpms off".toUTF8
  unix.recv 4096 >>= IO.print ∘ String.fromUTF8Unchecked
```

Realised my alloy update was the same as the one already there after rebasing, I had also updated std4 locally, but that's not really required by anything so I discarded that bit.