### PR TITLE
Get the underlying file descriptor

### DIFF
--- a/Socket.lean
+++ b/Socket.lean
@@ -105,6 +105,16 @@ def close (socket : @& Socket) : IO Unit := {
   }
 }
 
+/--
+Get the underlying file descriptior. Use with caution, specifically make sure
+you keep `Socket` alive while using the file descriptor.
+-/
+alloy c extern "lean_socket_fd"
+def getFd (socket : @& Socket) : UInt32 := {
+  int fd = *of_lean<Socket>(socket);
+  return (uint32_t)fd;
+}
+
 alloy c section
 static void sockaddr_in_finalize(void* ptr) {
   free((struct sockaddr_in*)ptr);


### PR DESCRIPTION
Hello. First of all, thank you for making this package!

I'm working on [http-client for lean4](https://github.com/Yuras/lean4-http-client), and I'm using your package for the socket API.
Right now I'm adding https support using openssl, and I need to pass socket to [SSL_set_fd](https://www.openssl.org/docs/man3.1/man3/SSL_set_fd.html). I didn't find a way to get access to the underlying FD, so I went ahead and added a function for that.