### PR TITLE
fix: forgot to correctly marshal/unmarshal SockFamily

### DIFF
--- a/Socket.lean
+++ b/Socket.lean
@@ -237,15 +237,15 @@ instance : Coe SockAddrUnix SockAddr where
 
 alloy c extern "lean_sockaddr_in_family"
 def SockAddr4.family (addr : @& SockAddr4) : AddressFamily :=
-  return of_lean<SockAddr4>(addr)->sin_family;
+  return to_lean<AddressFamily>(of_lean<SockAddr4>(addr)->sin_family);
 
 alloy c extern "lean_sockaddr_in6_family"
 def SockAddr6.family (addr : @& SockAddr6) : AddressFamily :=
-  return of_lean<SockAddr6>(addr)->sin6_family;
+  return to_lean<AddressFamily>(of_lean<SockAddr6>(addr)->sin6_family);
 
 alloy c extern "lean_sockaddr_un_family"
 def SockAddrUnix.family (addr : @& SockAddrUnix) : AddressFamily :=
-  return of_lean<SockAddrUnix>(addr)->sun_family;
+  return to_lean<AddressFamily>(of_lean<SockAddrUnix>(addr)->sun_family);
 
 /--
 Get the `AddressFamily` of a `SockAddr`.


### PR DESCRIPTION
closes: #12 

The issue description is not quite correct here. If the object did truly store the wrong thing
at the C level the package would be in total disfunction. Instead the issue is that I forgot to apply the correct marshalling function when recovering the `family`. Subsequent failures are caused as the integer to represent SockFamily is not in the range expected by the alloy code.